### PR TITLE
Use Python 3.7 and install missing C dependencies

### DIFF
--- a/base_image/installer.sh
+++ b/base_image/installer.sh
@@ -5,6 +5,10 @@ yum -y install zlib-devel
 yum -y install openssl-devel
 yum -y install wget
 
+# This is a duplicate of the apt-get libffi-dev below
+# Need to determine which one to keep through testing it out
+yum -y install libffi-devel
+
 # Installing openssl-devel alone seems to result in SSL errors in pip (see https://medium.com/@moreless/pip-complains-there-is-no-ssl-support-in-python-edbdce548852)
 # Need to install OpenSSL also to avoid these errors
 wget https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz
@@ -20,19 +24,25 @@ cd ..
 rm OpenSSL_1_0_2l.tar.gz
 rm -rf openssl-OpenSSL_1_0_2l/
 
+apt-get install libffi-dev
+apt-get install libpython-dev
+apt-get install python3-lxml
 
 # Install Python 3.6
-wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz
-tar xJf Python-3.6.0.tar.xz
-cd Python-3.6.0
+wget https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz
+tar xJf Python-3.7.0.tar.xz
+cd Python-3.7.0
 
 ./configure
 make
 make install
 
 cd ..
-rm Python-3.6.0.tar.xz
-rm -rf Python-3.6.0
+rm Python-3.7.0.tar.xz
+rm -rf Python-3.7.0
+
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py --force-reinstall
 
 
 # # Create virtualenv running Python 3.6

--- a/dockerfile
+++ b/dockerfile
@@ -8,6 +8,6 @@ COPY /requirements.txt package/requirements.txt
 
 WORKDIR /package
 
-RUN pip3 install -r requirements.txt -t .
+RUN python3 -m pip install -r requirements.txt -t .
 
 RUN zip -r deployment_package.zip . -x "requirements.txt"


### PR DESCRIPTION
This PR upgrades the lambda native package builder to use Python 3.7 in the Docker image that it builds.

It also adds missing dependencies which are required for the compilation of of various Python packages, such as PyYAML, which relies on certain C libraries being installed on the system.